### PR TITLE
refactor: enhance test readability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,18 @@ jobs:
       - name: Tidy
         run: go mod tidy && git diff --exit-code
 
+      - name: Install gotestfmt
+        uses: gotesttools/gotestfmt-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Test
         run: |
+          set -euo pipefail
           mkdir -p "${{ runner.temp }}/covdata"
-          go test -v -cover ./...  -test.gocoverdir="${{ runner.temp }}/covdata"
-          go tool covdata percent -i="${{ runner.temp }}/covdata"
+          go test -v -cover ./... -json -test.gocoverdir="${{ runner.temp }}/covdata" 2>&1 | tee "${{ runner.temp }}/test.log" | gotestfmt
           go tool covdata textfmt -o "${{ runner.temp }}/coverage.out" -i="${{ runner.temp }}/covdata"
+          go tool covdata percent -i="${{ runner.temp }}/covdata"
 
       - name: Coverage report
         uses: ncruces/go-coverage-report@v0
@@ -32,7 +38,15 @@ jobs:
           coverage-file: "${{ runner.temp }}/coverage.out"
           report: true
           chart: true
-          amend: true
         if: |
           github.event_name == 'push'
         continue-on-error: true
+
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-logs
+          path: |
+            ${{ runner.temp }}/test.log
+            ${{ runner.temp }}/coverage.out

--- a/cmd/vermockgen/main_test.go
+++ b/cmd/vermockgen/main_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 var env []string
+var covdir *string
 
 func TestMockgen(t *testing.T) {
 	ctx, eng := context.Background(), script.NewEngine()
@@ -43,7 +44,7 @@ func TestMain(m *testing.M) {
 	// test script.
 	fset := flag.NewFlagSet("vermockgen", flag.ContinueOnError)
 	fset.SetOutput(&bytes.Buffer{}) // ignore errors
-	covdir := fset.String("test.gocoverdir", "", "write coverage intermediate files to this directory")
+	covdir = fset.String("test.gocoverdir", "", "write coverage intermediate files to this directory")
 	err = fset.Parse(os.Args[1:])
 	for err != nil {
 		err = fset.Parse(fset.Args())

--- a/cmd/vermockgen/testdata/commands.txt
+++ b/cmd/vermockgen/testdata/commands.txt
@@ -17,9 +17,3 @@ module test
 go 1.20
 
 require github.com/Versent/go-vermock v0.0.0-00010101000000-000000000000
--- tools.go --
-package main
-
-import (
-	_ "github.com/Versent/go-vermock/cmd/vermockgen"
-)

--- a/cmd/vermockgen/testdata/fallback.txt
+++ b/cmd/vermockgen/testdata/fallback.txt
@@ -14,12 +14,6 @@ module test
 go 1.20
 
 require github.com/Versent/go-vermock v0.0.0-00010101000000-000000000000
--- tools.go --
-package main
-
-import (
-	_ "github.com/Versent/go-vermock/cmd/vermockgen"
-)
 -- mock.go --
 //go:build vermockstub
 

--- a/cmd/vermockgen/testdata/fallback_all_args.txt
+++ b/cmd/vermockgen/testdata/fallback_all_args.txt
@@ -14,12 +14,6 @@ module test
 go 1.20
 
 require github.com/Versent/go-vermock v0.0.0-00010101000000-000000000000
--- tools.go --
-package main
-
-import (
-	_ "github.com/Versent/go-vermock/cmd/vermockgen"
-)
 -- HEADER --
 // HEADER
 -- mock.go --

--- a/cmd/vermockgen/testdata/fallback_flag_undefined.txt
+++ b/cmd/vermockgen/testdata/fallback_flag_undefined.txt
@@ -24,9 +24,3 @@ module test
 go 1.20
 
 require github.com/Versent/go-vermock v0.0.0-00010101000000-000000000000
--- tools.go --
-package main
-
-import (
-	_ "github.com/Versent/go-vermock/cmd/vermockgen"
-)

--- a/cmd/vermockgen/testdata/fallback_header.txt
+++ b/cmd/vermockgen/testdata/fallback_header.txt
@@ -14,12 +14,6 @@ module test
 go 1.20
 
 require github.com/Versent/go-vermock v0.0.0-00010101000000-000000000000
--- tools.go --
-package main
-
-import (
-	_ "github.com/Versent/go-vermock/cmd/vermockgen"
-)
 -- HEADER --
 // HEADER
 -- mock.go --

--- a/cmd/vermockgen/testdata/fallback_packages_missing.txt
+++ b/cmd/vermockgen/testdata/fallback_packages_missing.txt
@@ -15,9 +15,3 @@ module test
 go 1.20
 
 require github.com/Versent/go-vermock v0.0.0-00010101000000-000000000000
--- tools.go --
-package main
-
-import (
-	_ "github.com/Versent/go-vermock/cmd/vermockgen"
-)

--- a/cmd/vermockgen/testdata/fallback_tags.txt
+++ b/cmd/vermockgen/testdata/fallback_tags.txt
@@ -14,12 +14,6 @@ module test
 go 1.20
 
 require github.com/Versent/go-vermock v0.0.0-00010101000000-000000000000
--- tools.go --
-package main
-
-import (
-	_ "github.com/Versent/go-vermock/cmd/vermockgen"
-)
 -- mock.go --
 //go:build vermockstub
 

--- a/cmd/vermockgen/testdata/flags.txt
+++ b/cmd/vermockgen/testdata/flags.txt
@@ -13,9 +13,3 @@ module test
 go 1.20
 
 require github.com/Versent/go-vermock v0.0.0-00010101000000-000000000000
--- tools.go --
-package main
-
-import (
-	_ "github.com/Versent/go-vermock/cmd/vermockgen"
-)

--- a/cmd/vermockgen/testdata/flags_gen.txt
+++ b/cmd/vermockgen/testdata/flags_gen.txt
@@ -17,9 +17,3 @@ module test
 go 1.20
 
 require github.com/Versent/go-vermock v0.0.0-00010101000000-000000000000
--- tools.go --
-package main
-
-import (
-	_ "github.com/Versent/go-vermock/cmd/vermockgen"
-)

--- a/cmd/vermockgen/testdata/gen.txt
+++ b/cmd/vermockgen/testdata/gen.txt
@@ -14,12 +14,6 @@ module test
 go 1.20
 
 require github.com/Versent/go-vermock v0.0.0-00010101000000-000000000000
--- tools.go --
-package main
-
-import (
-	_ "github.com/Versent/go-vermock/cmd/vermockgen"
-)
 -- mock.go --
 //go:build vermockstub
 

--- a/cmd/vermockgen/testdata/gen_all_args.txt
+++ b/cmd/vermockgen/testdata/gen_all_args.txt
@@ -14,12 +14,6 @@ module test
 go 1.20
 
 require github.com/Versent/go-vermock v0.0.0-00010101000000-000000000000
--- tools.go --
-package main
-
-import (
-	_ "github.com/Versent/go-vermock/cmd/vermockgen"
-)
 -- HEADER --
 // HEADER
 -- mock.go --

--- a/cmd/vermockgen/testdata/gen_flag_undefined.txt
+++ b/cmd/vermockgen/testdata/gen_flag_undefined.txt
@@ -24,9 +24,3 @@ module test
 go 1.20
 
 require github.com/Versent/go-vermock v0.0.0-00010101000000-000000000000
--- tools.go --
-package main
-
-import (
-	_ "github.com/Versent/go-vermock/cmd/vermockgen"
-)

--- a/cmd/vermockgen/testdata/gen_header.txt
+++ b/cmd/vermockgen/testdata/gen_header.txt
@@ -14,12 +14,6 @@ module test
 go 1.20
 
 require github.com/Versent/go-vermock v0.0.0-00010101000000-000000000000
--- tools.go --
-package main
-
-import (
-	_ "github.com/Versent/go-vermock/cmd/vermockgen"
-)
 -- HEADER --
 // HEADER
 -- mock.go --

--- a/cmd/vermockgen/testdata/gen_package.txt
+++ b/cmd/vermockgen/testdata/gen_package.txt
@@ -14,12 +14,6 @@ module test
 go 1.20
 
 require github.com/Versent/go-vermock v0.0.0-00010101000000-000000000000
--- tools.go --
-package main
-
-import (
-	_ "github.com/Versent/go-vermock/cmd/vermockgen"
-)
 -- mock.go --
 //go:build vermockstub
 

--- a/cmd/vermockgen/testdata/gen_tags.txt
+++ b/cmd/vermockgen/testdata/gen_tags.txt
@@ -14,12 +14,6 @@ module test
 go 1.20
 
 require github.com/Versent/go-vermock v0.0.0-00010101000000-000000000000
--- tools.go --
-package main
-
-import (
-	_ "github.com/Versent/go-vermock/cmd/vermockgen"
-)
 -- mock.go --
 //go:build vermockstub
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/Versent/go-vermock
 
-go 1.20
+go 1.21
+
+toolchain go1.21.6
 
 require (
 	github.com/google/subcommands v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3
 golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
 golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
+golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/tools v0.16.0 h1:GO788SKMRunPIBCXiQyo2AaexLstOrVhuAL5YwsckQM=

--- a/internal/cmd/vermockgen/gen_test.go
+++ b/internal/cmd/vermockgen/gen_test.go
@@ -1,0 +1,36 @@
+package vermockgen_test
+
+import (
+	"bytes"
+	"flag"
+	"log"
+	"testing"
+
+	vermockgen "github.com/Versent/go-vermock/internal/cmd/vermockgen"
+)
+
+func TestSetFlags(t *testing.T) {
+	f := flag.NewFlagSet("vermockgen", flag.ContinueOnError)
+	vermockgen.NewGenCmd(nil, f)
+	expected := []string{"header", "tags"}
+	f.VisitAll(func(f *flag.Flag) {
+		if len(expected) == 0 {
+			t.Errorf("unexpected flag %q", f.Name)
+			return
+		}
+
+		var got, want string
+		got, want, expected = f.Name, expected[0], expected[1:]
+		if got != want {
+			t.Errorf("unexpected name, got %q, want %q", got, want)
+		}
+	})
+}
+
+func TestExecute(t *testing.T) {
+	var buf bytes.Buffer
+	l := log.New(&buf, "", 0)
+	f := flag.NewFlagSet("vermockgen", flag.ContinueOnError)
+	vermockgen.NewGenCmd(l, f)
+
+}

--- a/internal/mock/generate_test.go
+++ b/internal/mock/generate_test.go
@@ -30,7 +30,11 @@ func TestGenerate(t *testing.T) {
 		t,
 		context.Background(),
 		engine,
-		[]string{"MUT=" + mutdir},
+		[]string{
+			"PATH=" + os.Getenv("PATH"),
+			"HOME=" + os.Getenv("HOME"),
+			"MUT=" + mutdir,
+		},
 		"testdata/*.txt",
 	)
 }

--- a/internal/mock/testdata/custom_func.txt
+++ b/internal/mock/testdata/custom_func.txt
@@ -3,6 +3,8 @@
 
 replace ../../../.. $MUT go.mod
 
+exec go mod tidy
+
 vermockgen
 
 cmpenv stdout testdata/stdout

--- a/internal/mock/testdata/custom_func_multi_expect.txt
+++ b/internal/mock/testdata/custom_func_multi_expect.txt
@@ -3,6 +3,8 @@
 
 replace ../../../.. $MUT go.mod
 
+exec go mod tidy
+
 vermockgen
 
 cmpenv stdout testdata/stdout

--- a/internal/mock/testdata/custom_func_multi_file.txt
+++ b/internal/mock/testdata/custom_func_multi_file.txt
@@ -3,6 +3,8 @@
 
 replace ../../../.. $MUT go.mod
 
+exec go mod tidy
+
 vermockgen
 
 cmpenv stdout testdata/stdout

--- a/mod_test.go
+++ b/mod_test.go
@@ -3,6 +3,8 @@ package vermock_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -10,15 +12,18 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"rsc.io/script"
 	"rsc.io/script/scripttest"
 )
 
 var env []string
+var covdir *string
 
 func TestModules(t *testing.T) {
 	ctx, eng := context.Background(), script.NewEngine()
+	eng.Cmds["go-test"] = GoTestCommand(*covdir)
 	scripttest.Test(t, ctx, eng, env, "testdata/*.txt")
 }
 
@@ -40,7 +45,7 @@ func TestMain(m *testing.M) {
 	// test script.
 	fset := flag.NewFlagSet("vermockgen", flag.ContinueOnError)
 	fset.SetOutput(&bytes.Buffer{}) // ignore errors
-	covdir := fset.String("test.gocoverdir", "", "write coverage intermediate files to this directory")
+	covdir = fset.String("test.gocoverdir", "", "write coverage intermediate files to this directory")
 	err = fset.Parse(os.Args[1:])
 	for err != nil {
 		err = fset.Parse(fset.Args())
@@ -73,4 +78,92 @@ func TestMain(m *testing.M) {
 	env = append(env, "PATH="+strings.Join([]string{bindir, os.Getenv("PATH")}, ":"))
 
 	m.Run()
+}
+
+type goTestCmd struct {
+	covdir string
+}
+
+func GoTestCommand(covdir string) *goTestCmd {
+	return &goTestCmd{covdir: covdir}
+}
+
+func (*goTestCmd) Usage() *script.CmdUsage {
+	return &script.CmdUsage{
+		Summary: "wrapper for the go test command",
+		Args:    "go-test [build/test flags] [packages] [build/test flags & test binary flags]",
+		Detail: []string{
+			`The standard go test command output includes data about elapsed time and code `,
+			`coverage. This can be a hinderance when comparing the output of two test runs. `,
+			`This wrapper will strip out all the non-reproducible data from the output. It `,
+			`also automatically sets the -coverpkg and -test.gocoverdir flags if the `,
+			`GOCOVERDIR environment variable is set.`,
+		},
+	}
+}
+
+func (cmd *goTestCmd) Run(s *script.State, args ...string) (script.WaitFunc, error) {
+	var buf, stderr bytes.Buffer
+	goargs := []string{"test", "-json"}
+	if cmd.covdir != "" {
+		goargs = append(
+			goargs,
+			"-coverpkg=github.com/Versent/go-vermock/...",
+			"-test.gocoverdir="+cmd.covdir,
+		)
+	}
+	goargs = append(goargs, args...)
+	gocmd := exec.CommandContext(s.Context(), "go", goargs...)
+	gocmd.Dir = s.Getwd()
+	gocmd.Env = s.Environ()
+	gocmd.Stdout = &buf
+	gocmd.Stderr = &stderr
+	err := gocmd.Start()
+
+	return func(s *script.State) (_, _ string, err error) {
+		err = gocmd.Wait()
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			err = nil
+		}
+		if err != nil {
+			println(stderr.String(), err.Error())
+			return "", stderr.String(), err
+		}
+
+		var stdout strings.Builder
+		decoder := json.NewDecoder(&buf)
+
+		for decoder.More() {
+			var event struct {
+				Time    time.Time
+				Action  string
+				Package string
+				Test    string
+				Elapsed float64
+				Output  string
+			}
+			if err := decoder.Decode(&event); err != nil {
+				return "", stderr.String(), err
+			}
+			if event.Test == "" {
+				continue
+			}
+			switch event.Action {
+			case "start", "run", "pause", "cont", "bench":
+				continue
+			case "output":
+				if strings.HasPrefix(strings.TrimSpace(event.Output), "--- ") {
+					continue
+				}
+				stdout.WriteString(event.Output)
+			case "pass", "fail", "skip":
+				fmt.Fprintf(&stdout, "--- %s: %s\n", strings.ToUpper(event.Action), event.Test)
+			}
+		}
+		if exitErr != nil {
+			fmt.Fprintln(&stdout, exitErr.Error())
+		}
+		return stdout.String(), stderr.String(), err
+	}, err
 }

--- a/mod_test.go
+++ b/mod_test.go
@@ -1,0 +1,76 @@
+package vermock_test
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"rsc.io/script"
+	"rsc.io/script/scripttest"
+)
+
+var env []string
+
+func TestModules(t *testing.T) {
+	ctx, eng := context.Background(), script.NewEngine()
+	scripttest.Test(t, ctx, eng, env, "testdata/*.txt")
+}
+
+func TestMain(m *testing.M) {
+	// Setup environment for scripttest.
+	env = []string{
+		"HOME=" + os.Getenv("HOME"),
+	}
+
+	// The Module Under Test (MUT) directory.
+	mutdir, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	env = append(env, "MUT="+mutdir)
+
+	// When running with -test.gocoverdir, forward this setting to each
+	// test script.
+	fset := flag.NewFlagSet("vermockgen", flag.ContinueOnError)
+	fset.SetOutput(&bytes.Buffer{}) // ignore errors
+	covdir := fset.String("test.gocoverdir", "", "write coverage intermediate files to this directory")
+	err = fset.Parse(os.Args[1:])
+	for err != nil {
+		err = fset.Parse(fset.Args())
+	}
+
+	if *covdir != "" {
+		env = append(env, "GOCOVERDIR="+*covdir)
+	}
+
+	// Temporary directory for vermockgen binary.
+	bindir, err := os.MkdirTemp("", "vermockgen")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(bindir)
+	args := []string{"build"}
+	if *covdir != "" {
+		args = append(args, "-cover")
+	}
+	args = append(args, "-o", filepath.Join(bindir, "vermockgen"), "./cmd/vermockgen")
+	cmd := exec.Command("go", args...)
+	cmd.Env = env
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	env = append(env, "PATH="+strings.Join([]string{bindir, os.Getenv("PATH")}, ":"))
+
+	m.Run()
+}

--- a/testdata/example.txt
+++ b/testdata/example.txt
@@ -1,11 +1,27 @@
-package vermock_test
+# Complete example usage of vermockgen.
+#
+# For a description of this format see https://pkg.go.dev/golang.org/x/tools/txtar and https://pkg.go.dev/rsc.io/script@v0.0.1#hdr-Script_Language.
 
-import (
-	"fmt"
-	"testing"
+# Setup module.
+exec go mod edit -replace github.com/Versent/go-vermock=$MUT
+exec go mod tidy
 
-	vermock "github.com/Versent/go-vermock"
-)
+# Run vermockgen.
+exec vermockgen
+
+# Run go test and strip out elapsed time and coverage data.
+exec bash -c 'go test -v ${GOCOVERDIR:+-coverpkg=github.com/Versent/go-vermock/... -test.gocoverdir=$GOCOVERDIR} | sed "/\\scoverage:\\s/d;s/\\s*\\(([0-9.]\\+s)\\|\t[0-9.]\\+s\\)$//"'
+
+# Compare with expected output
+cmpenv stdout testdata/stdout
+cmpenv stderr testdata/stderr
+
+-- go.mod --
+module example.com
+
+go 1.20
+-- example.go --
+package example
 
 // Cache contains a variety of methods with different signatures.
 type Cache interface {
@@ -14,63 +30,51 @@ type Cache interface {
 	Delete(string)
 	Load(...string)
 }
+-- mock_test.go --
+//go:build vermockstub
 
-// mockCache is a mock implementation of Cache.  It can be anything, but
-// zero-sized types are problematic.
+package example_test
+
+import (
+	eg "example.com"
+)
+
 type mockCache struct {
-	_ byte // prevent zero-sized type
-}
-
-// Put returns one value, so use vermock.Call1.
-func (m *mockCache) Put(key string, value any) error {
-	return vermock.Call1[error](m, "Put", key, value)
-}
-
-// Get returns two values, so use vermock.Call2.
-func (m *mockCache) Get(key string) (any, bool) {
-	return vermock.Call2[any, bool](m, "Get", key)
-}
-
-// Delete returns no values, so use vermock.Call0.
-func (m *mockCache) Delete(key string) {
-	vermock.Call0(m, "Delete", key)
-}
-
-// Load is variadic, the last argument must be passed as a slice to one of the
-// vermock.CallN functions.
-func (m *mockCache) Load(keys ...string) {
-	vermock.Call0(m, "Load", keys)
+	eg.Cache
 }
 
 // UnusedCache is useful to show that a test's intent is that none of the
 // interface methods are called.
 var UnusedCache func(*mockCache) = nil
+-- example_test.go --
+// To avoid problems when generating vermockgen code after the tests are
+// defined, use buildtags to hide this file from the generator.
+// Alternatively, just ensure the vermockgen code is generated before writing
+// your tests (and don't forget to commit it to your SCM system).
+//go:build !vermockstub
 
-func ExampleUnusedCache() {
-	// See ./testdata/example.txt for a full example.
-	t := &exampleT{} // or any testing.TB, your test does not create this
+package example_test
+
+import (
+	"fmt"
+	"testing"
+
+	vermock "github.com/Versent/go-vermock"
+
+	eg "example.com"
+)
+
+func TestUnusedCache(t *testing.T) {
 	// 1. Create a mock object.
-	var cache Cache = vermock.New(t, UnusedCache)
+	var cache eg.Cache = vermock.New(t, UnusedCache)
 	// 2. Use the mock object in your code under test.
 	// 3. Assert that all expected methods were called.
 	vermock.AssertExpectedCalls(t, cache)
-	// mock will fail a test if a call is made to an unexpected method or if
-	// the expected methods are not called.
-	fmt.Println("less than expected:", t.Failed())
-	// Output:
-	// less than expected: false
 }
 
-// ExpectDelete is a helper function that hides the stringiness of vermock.
-func ExpectDelete(delegate func(t testing.TB, key string)) func(*mockCache) {
-	return vermock.Expect[mockCache]("Delete", delegate)
-}
-
-func Example_pass() {
-	// See ./testdata/example.txt for a full example.
-	t := &exampleT{} // or any testing.TB, your test does not create this
+func TestPass(t *testing.T) {
 	// 1. Create a mock object with expected calls.
-	var cache Cache = vermock.New(t,
+	var cache eg.Cache = vermock.New(t,
 		// delegate function can receive testing.TB
 		vermock.Expect[mockCache]("Get", func(t testing.TB, key string) (any, bool) {
 			return "bar", true
@@ -90,21 +94,11 @@ func Example_pass() {
 	cache.Delete("foo")
 	// 3. Assert that all expected methods were called.
 	vermock.AssertExpectedCalls(t, cache)
-	// mock will not fail the test
-	fmt.Println("less than expected:", t.Failed())
-	// Output:
-	// call to Put: 0/0
-	// call to Get: 0/0
-	// call to Delete: 0/0
-	// call to Delete: 1/0
-	// less than expected: false
 }
 
-func Example_unmetExpectation() {
-	// See ./testdata/example.txt for a full example.
-	t := &testing.T{} // or any testing.TB, your test does not create this
+func TestUnmetExpectation(t *testing.T) {
 	// 1. Create a mock object with expected calls.
-	var cache Cache = vermock.New(t,
+	var cache eg.Cache = vermock.New(t,
 		// delegate function can receive testing.TB
 		vermock.Expect[mockCache]("Put", func(t testing.TB, key string, value any) error {
 			fmt.Println("put", key, value)
@@ -130,20 +124,11 @@ func Example_unmetExpectation() {
 	cache.Delete("foo")
 	// 3. Assert that all expected methods were called.
 	vermock.AssertExpectedCalls(t, cache)
-	// mock will fail the test because the second call to Delete is not met.
-	fmt.Println("less than expected:", t.Failed())
-	// Output:
-	// put foo bar
-	// get foo
-	// delete foo
-	// less than expected: true
 }
 
-func Example_unexpectedCall() {
-	// See ./testdata/example.txt for a full example.
-	t := &testing.T{} // or any testing.TB, your test does not create this
+func TestUnexpectedCall(t *testing.T) {
 	// 1. Create a mock object with expected calls.
-	var cache Cache = vermock.New(t,
+	var cache eg.Cache = vermock.New(t,
 		// delegate function can receive testing.TB
 		vermock.Expect[mockCache]("Put", func(t testing.TB, key string, value any) error {
 			fmt.Println("put", key, value)
@@ -160,19 +145,11 @@ func Example_unexpectedCall() {
 	cache.Delete("foo")
 	// 3. Assert that all expected methods were called.
 	vermock.AssertExpectedCalls(t, cache)
-	// mock will fail the test because the call to Get is not expected.
-	fmt.Println("more than expected:", t.Failed())
-	// Output:
-	// put foo bar
-	// delete foo
-	// more than expected: true
 }
 
-func Example_allowRepeatedCalls() {
-	// See ./testdata/example.txt for a full example.
-	t := &testing.T{} // or any testing.TB, your test does not create this
+func TestAllowRepeatedCalls(t *testing.T) {
 	// 1. Create a mock object with ExpectMany.
-	var cache Cache = vermock.New(t,
+	var cache eg.Cache = vermock.New(t,
 		// delegate function may receive a call counter and the method arguments
 		vermock.ExpectMany[mockCache]("Load", func(n vermock.CallCount, keys ...string) {
 			fmt.Println("load", n, keys)
@@ -203,23 +180,11 @@ func Example_allowRepeatedCalls() {
 	cache.Load("foo", "bar", "baz")
 	// 3. Assert that all expected methods were called.
 	vermock.AssertExpectedCalls(t, cache)
-	// mock will not fail the test because ExpectMany allows repeated calls.
-	fmt.Println("more than expected:", t.Failed())
-	// Output:
-	// load 0 [foo bar]
-	// load 1 [baz]
-	// load 2 [foo]
-	// load 3 [bar]
-	// load 4 [baz]
-	// load 4 [foo bar baz]
-	// more than expected: false
 }
 
-func Example_orderedCalls() {
-	// See ./testdata/example.txt for a full example.
-	t := &testing.T{} // or any testing.TB, your test does not create this
+func TestOrderedCalls(t *testing.T) {
 	// 1. Create a mock object with ExpectInOrder.
-	var cache Cache = vermock.New(t,
+	var cache eg.Cache = vermock.New(t,
 		vermock.ExpectInOrder(
 			vermock.Expect[mockCache]("Put", func(key string, value any) error {
 				fmt.Println("put", key, value)
@@ -236,18 +201,9 @@ func Example_orderedCalls() {
 	cache.Put("foo", "bar")
 	// 3. Assert that all expected methods were called.
 	vermock.AssertExpectedCalls(t, cache)
-	// mock will fail the test because the call to Get is before the call
-	// to Put.
-	fmt.Println("less than expected:", t.Failed())
-	// Output:
-	// get foo
-	// put foo bar
-	// less than expected: true
 }
 
-func Example_mixedOrderedCalls() {
-	// See ./testdata/example.txt for a full example.
-	t := &exampleT{} // or any testing.TB, your test does not create this
+func TestMixedOrderedCalls(t *testing.T) {
 	// 1. Create a mock object with ExpectInOrder.
 	get := vermock.Expect[mockCache]("Get", func(key string) (any, bool) {
 		return "bar", true
@@ -255,7 +211,7 @@ func Example_mixedOrderedCalls() {
 	put := vermock.Expect[mockCache]("Put", func(key string, value any) error {
 		return nil
 	})
-	var cache Cache = vermock.New(t,
+	var cache eg.Cache = vermock.New(t,
 		get, put,
 		vermock.ExpectInOrder(put, get),
 		get, put,
@@ -267,48 +223,63 @@ func Example_mixedOrderedCalls() {
 	}
 	// 3. Assert that all expected methods were called.
 	vermock.AssertExpectedCalls(t, cache)
-	// mock will not fail the test
-	fmt.Println("less than expected:", t.Failed())
-	// Output:
-	// call to Put: 0/0
-	// call to Get: 0/0
-	// call to Put: 1/1
-	// call to Get: 1/2
-	// call to Put: 2/2
-	// call to Get: 2/2
-	// less than expected: false
 }
-
-var _ testing.TB = &exampleT{}
-
-type exampleT struct {
-	testing.T
-}
-
-func (t *exampleT) Fatal(args ...any) {
-	fmt.Println(args...)
-	t.T.FailNow()
-}
-
-func (t *exampleT) Fatalf(format string, args ...any) {
-	fmt.Printf(format+"\n", args...)
-	t.T.FailNow()
-}
-
-func (t *exampleT) Error(args ...any) {
-	fmt.Println(args...)
-	t.T.Fail()
-}
-
-func (t *exampleT) Errorf(format string, args ...any) {
-	fmt.Printf(format+"\n", args...)
-	t.T.Fail()
-}
-
-func (t *exampleT) Log(args ...any) {
-	fmt.Println(args...)
-}
-
-func (t *exampleT) Logf(format string, args ...any) {
-	fmt.Printf(format+"\n", args...)
-}
+-- testdata/stderr --
+-- testdata/stdout --
+=== RUN   TestUnusedCache
+--- PASS: TestUnusedCache
+=== RUN   TestPass
+    vermock_gen_test.go:65: call to Put: 0/0
+    vermock_gen_test.go:41: call to Get: 0/0
+    vermock_gen_test.go:29: call to Delete: 0/0
+    vermock_gen_test.go:29: call to Delete: 1/0
+--- PASS: TestPass
+=== RUN   TestUnmetExpectation
+    vermock_gen_test.go:65: call to Put: 0/0
+put foo bar
+    vermock_gen_test.go:41: call to Get: 0/0
+get foo
+    vermock_gen_test.go:29: call to Delete: 0/0
+delete foo
+    example_test.go:77: failed to make call to Delete: only got one call
+--- FAIL: TestUnmetExpectation
+=== RUN   TestUnexpectedCall
+    vermock_gen_test.go:65: call to Put: 0/0
+put foo bar
+    vermock_gen_test.go:41: unexpected call to Get
+    vermock_gen_test.go:29: call to Delete: 0/0
+delete foo
+--- FAIL: TestUnexpectedCall
+=== RUN   TestAllowRepeatedCalls
+    vermock_gen_test.go:53: call to Load: 0/0
+load 0 [foo bar]
+    vermock_gen_test.go:53: call to Load: 1/0
+load 1 [baz]
+    vermock_gen_test.go:53: call to Load: 2/0
+load 2 [foo]
+    vermock_gen_test.go:53: call to Load: 3/0
+load 3 [bar]
+    vermock_gen_test.go:53: call to Load: 4/0
+load 4 [baz]
+    vermock_gen_test.go:53: call to Load: 5/0
+load 4 [foo bar baz]
+--- PASS: TestAllowRepeatedCalls
+=== RUN   TestOrderedCalls
+    vermock_gen_test.go:41: out of order call to Get: expected 2, got 1
+    vermock_gen_test.go:41: call to Get: 0/1
+get foo
+    vermock_gen_test.go:65: out of order call to Put: expected 1, got 2
+    vermock_gen_test.go:65: call to Put: 0/2
+put foo bar
+--- FAIL: TestOrderedCalls
+=== RUN   TestMixedOrderedCalls
+    vermock_gen_test.go:65: call to Put: 0/0
+    vermock_gen_test.go:41: call to Get: 0/0
+    vermock_gen_test.go:65: call to Put: 1/1
+    vermock_gen_test.go:41: call to Get: 1/2
+    vermock_gen_test.go:65: call to Put: 2/2
+    vermock_gen_test.go:41: call to Get: 2/2
+--- PASS: TestMixedOrderedCalls
+FAIL
+exit status 1
+FAIL	example.com

--- a/testdata/example.txt
+++ b/testdata/example.txt
@@ -10,7 +10,7 @@ exec go mod tidy
 exec vermockgen
 
 # Run go test and strip out elapsed time and coverage data.
-exec bash -c 'go test -v ${GOCOVERDIR:+-coverpkg=github.com/Versent/go-vermock/... -test.gocoverdir=$GOCOVERDIR} | sed "/\\scoverage:\\s/d;s/\\s*\\(([0-9.]\\+s)\\|\t[0-9.]\\+s\\)$//"'
+go-test -v
 
 # Compare with expected output
 cmpenv stdout testdata/stdout
@@ -280,6 +280,4 @@ put foo bar
     vermock_gen_test.go:65: call to Put: 2/2
     vermock_gen_test.go:41: call to Get: 2/2
 --- PASS: TestMixedOrderedCalls
-FAIL
 exit status 1
-FAIL	example.com


### PR DESCRIPTION
- chore: update to go 1.21

  Prior to this change, we using go 1.20.

  This change updates to go 1.21 and introduces the toolchain directive. With this update the tools.go file is no longer required for the test cases and it also highlighted some missing go mod tidy commands in the test cases.

- refactor: remove sed dependency

  Prior to this change, sed was used to remove the coverage results and timing data from test output of the test cases (i.e. where a test invoked `go test` via rsc.io/script).  This is important because the test not reproducible otherwise.  However, complex regular expressions to do this is fragile and difficult to change.

  This change wraps the go test command in a custom rsc.io/script command; this allows us to filter the JSON formatted test output using a go function.  Only the output relating to individual tests is outputed (i.e. summary information is excluded) and we generate our own result (i.e. pass/fail/skip) lines with the elapsed time removed.  Also, we now automatically pass the correct -coverpkg and -test.gocoverdir arguments without the conditional bash variable expansion polluting every txt archive file.

- chore: improve readability of test in GH actions

  Prior to this change, the test results are long and hard to see when one test ends and another starts.

  This change introduces gotestfmt tool which format go test output into coloured, collapsible sections.  Also, the original JSON output is uploaded in case of any issues, along with the raw coverage data.