### PR TITLE
chore: introduce fgrosse/go-coverage-report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,3 +50,14 @@ jobs:
           path: |
             ${{ runner.temp }}/test.log
             ${{ runner.temp }}/coverage.out
+
+  code_coverage:
+    name: Coverage review robot
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: fgrosse/go-coverage-report@v1.0.0
+        with:
+          coverage-artifact-name: test-logs
+          coverage-file-name: coverage.out


### PR DESCRIPTION
Prior to this change, the existing code coverage report step in the GitHub actions placed the report on the wiki, while this is good for a historical view it doesn't provide any immediate feedback during the pull request review process.

This change introduces fgrosse/go-coverage-report, which is capable of participating in the conversation of the pull request.